### PR TITLE
DEVOPS-559 Modify startup script nginx reload

### DIFF
--- a/start-txgh.sh
+++ b/start-txgh.sh
@@ -19,4 +19,4 @@ if [[ -n ${NGINX_CHANGES} ]]; then
 fi
 
 tee_logs "Reloading nginx"
-docker exec ec2-user_nginx_1 /bin/bash -c "nginx -s reload"
+docker exec ec2-user_nginx_1 nginx -s reload


### PR DESCRIPTION
Changed the nginx reload command in the startup script because it was
failing on the server.  Dropped the `/bin/bash` part of the command in
favor of calling `nginx -s reload` directly because `/bin/bash` was failing.